### PR TITLE
updates readme and fixes output

### DIFF
--- a/part-1/api/routes.js
+++ b/part-1/api/routes.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const router = express.Router()
 
-router.get('/supported-operations', (req, res) => {
+router.get('/supported-operators', (req, res) => {
 	const supportedOperations = {
 		"/": "division",
 	  "+": "addition",
@@ -32,16 +32,14 @@ router.post('/compute', (req, res, next) => {
 	} else if (operator === '*') {
 		result = operands[0] * operands[1]
 	} else {
-		result = {
-			"error": `invalid operator ${operator}. Valid operators are /, +, -, *`
-		}
+		res.status(404).send({"error": `invalid operator ${operator}. Valid operators are /, +, -, *`})
 	}
 
 	if (!isNaN(result)) {
 		result = result.toFixed(2)
 	}
 
-	res.json(result)
+	res.json({ 'result': JSON.parse(result) })
 })
 
 module.exports = router


### PR DESCRIPTION
- [x] 20: GET requests to the /api/supported-operators route responds with JSON content, as described in the example above
- [x] 80: POST requests to the /api/compute route add the two numbers provided in the request body and responds with the result. An invalid operator should return a 404.
- [x] 20: GET requests to the /api/square route squares the number provided in the query string variables number.